### PR TITLE
support table name with schema in postgres

### DIFF
--- a/fixtures/test_fixtures3.yml
+++ b/fixtures/test_fixtures3.yml
@@ -1,0 +1,8 @@
+- table: 'schema.some_table'
+  pk:
+    id: 1
+  fields:
+    string_field: 'foobar'
+    boolean_field: true
+    created_at: 'ON_INSERT_NOW()'
+    updated_at: 'ON_UPDATE_NOW()'

--- a/load_test.go
+++ b/load_test.go
@@ -58,6 +58,13 @@ CREATE TABLE string_key_table(
   created_at TIMESTAMP WITH TIME ZONE,
   updated_at TIMESTAMP WITH TIME ZONE
 );
+CREATE TABLE schema.some_table(
+  id INT PRIMARY KEY NOT NULL,
+  string_field VARCHAR(50) NOT NULL,
+  boolean_field BOOL NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE,
+  updated_at TIMESTAMP WITH TIME ZONE
+);
 `
 
 var testData = `
@@ -88,6 +95,14 @@ var testData = `
   fields:
     created_at: 'ON_INSERT_NOW()'
     updated_at: 'ON_UPDATE_NOW()'
+- table: 'schema.some_table'
+  pk:
+    id: 1
+  fields:
+    string_field: 'foobar'
+    boolean_field: true
+    created_at: 'ON_INSERT_NOW()'
+    updated_at: 'ON_UPDATE_NOW()'
 `
 
 var (
@@ -95,5 +110,6 @@ var (
 	fixtureFiles = []string{
 		"fixtures/test_fixtures1.yml",
 		"fixtures/test_fixtures2.yml",
+		"fixtures/test_fixtures3.yml",
 	}
 )


### PR DESCRIPTION
Currently, the table name in Yaml doesn't support schema. This pr is to support load data into a different schema than public in progress.
For example:

```yaml
- table: 'schema.some_table'
  pk:
    id: 1
  fields:
    string_field: 'foobar'
    boolean_field: true
    created_at: 'ON_INSERT_NOW()'
    updated_at: 'ON_UPDATE_NOW()'
```